### PR TITLE
Add script to fetch recent FB posts

### DIFF
--- a/FBPosts.sql
+++ b/FBPosts.sql
@@ -1,0 +1,10 @@
+CREATE TABLE FBPosts (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    post_id VARCHAR(50) UNIQUE NOT NULL,
+    post_url NVARCHAR(500) NOT NULL,
+    post_time DATETIME,
+    text NVARCHAR(MAX),
+    summary NVARCHAR(MAX),
+    attachments NVARCHAR(MAX)
+);
+GO

--- a/fetch_fb_posts.py
+++ b/fetch_fb_posts.py
@@ -1,0 +1,71 @@
+import os
+import json
+from datetime import datetime
+
+import pyodbc
+from facebook_scraper import get_posts
+from openai import OpenAI
+
+
+def get_db_conn():
+    conn_str = (
+        "Driver={ODBC Driver 17 for SQL Server};"
+        f"Server={os.environ.get('DB_HOST')};"
+        f"Database={os.environ.get('DB_NAME')};"
+        f"UID={os.environ.get('DB_USER')};"
+        f"PWD={os.environ.get('DB_PASS')}"
+    )
+    return pyodbc.connect(conn_str)
+
+
+def summarize(text: str, client: OpenAI) -> str:
+    if not text:
+        return ""
+    prompt = f"Summarize the following Facebook post in 3 sentences:\n{text}"
+    resp = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}]
+    )
+    return resp.choices[0].message.content.strip()
+
+
+def fetch_and_store(page: str, limit: int = 5):
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    if not openai_key:
+        raise RuntimeError("OPENAI_API_KEY not configured")
+    client = OpenAI(api_key=openai_key)
+
+    conn = get_db_conn()
+    cursor = conn.cursor()
+
+    count = 0
+    for post in get_posts(page, pages=2, options={"posts_per_page": 5}):
+        if count >= limit:
+            break
+        post_id = post.get("post_id")
+        url = post.get("post_url")
+        time_val = post.get("time")
+        text = post.get("text", "")
+        images = post.get("images")
+        video = post.get("video")
+        attachments = json.dumps({"images": images, "video": video}, default=str)
+        summary = summarize(text, client)
+
+        cursor.execute(
+            """
+            INSERT INTO FBPosts (post_id, post_url, post_time, text, summary, attachments)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            post_id, url, time_val, text, summary, attachments
+        )
+        conn.commit()
+        count += 1
+        print(f"Saved {url} ({time_val})")
+
+    cursor.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    fetch_and_store("CEBECOIIIToledo")
+


### PR DESCRIPTION
## Summary
- add `fetch_fb_posts.py` for scraping the latest Facebook posts
- include summarisation with OpenAI's GPT-3.5
- save posts into a new `FBPosts` table
- provide T-SQL script for creating the table

## Testing
- `python3 -m py_compile fetch_fb_posts.py`
- `pip install facebook-scraper openai pyodbc lxml_html_clean`
- `python fetch_fb_posts.py` *(fails: ODBC driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535ceb479c8333adf1581e66c3d91d